### PR TITLE
Améliore la page de Déclaration

### DIFF
--- a/src/obligations/declaration-accessibilite.md
+++ b/src/obligations/declaration-accessibilite.md
@@ -7,20 +7,23 @@ eleventyNavigation:
   order: 4
 ---
 
-## Contenu de la déclaration d’accessibilité
+<div class="fr-callout">
+    <p class="fr-callout__text">La déclaration d’accessibilité est le résultat d’une évaluation effective de la conformité du service de communication au public en ligne à la norme de référence.</p>
+</div>
 
-La déclaration d’accessibilité est le résultat d’une évaluation effective de la conformité du service de communication au public en ligne à la norme de référence.
 
 La déclaration d’accessibilité comprend :
 
-- un état de conformité :
+- un **état de conformité** :
   - Conformité totale : si tous les critères de contrôle du RGAA sont respectés
   - Conformité partielle : si au moins 50 % des critères de contrôle du RGAA sont respectés ;
   - Non-conformité : s’il n’existe aucun résultat d’audit en cours de validité permettant de mesurer le respect des critères ou si moins de 50 % des critères de contrôle du RGAA sont respectés ;
-- un signalement des contenus non accessibles, distingués selon qu’il s’agit de non-conformité avec le RGAA, de contenus exemptés ou de contenus soumis à dérogation pour charge disproportionnée. Dans ce dernier cas, les dérogations doivent être expliquées et motivées. Le signalement est assorti, le cas échéant, d’une présentation des alternatives accessibles prévues ;
-- des dispositifs d’assistance et de contact :
+- un **signalement des contenus non accessibles**, distingués selon qu’il s’agit de non-conformité avec le RGAA, de contenus exemptés ou de contenus soumis à dérogation pour charge disproportionnée. Dans ce dernier cas, les dérogations doivent être expliquées et motivées. Le signalement est assorti, le cas échéant, d’une présentation des alternatives accessibles prévues ;
+- des **dispositifs d’assistance et de contact** :
   - un mécanisme accessible (adresse électronique ou formulaire) pour permettre à toute personne de signaler à l’organisme concerné tout défaut d’accessibilité et à une personne handicapée de demander les informations correspondantes ou une solution alternative accessible ;
-- la mention de la faculté pour la personne concernée de saisir le Défenseur des droits, en cas d’absence de réponse ou de solution, une fois les démarches effectuées via le mécanisme mentionné ci-dessus.
+- la mention de la faculté pour la personne concernée de **saisir le Défenseur des droits**, en cas d’absence de réponse ou de solution, une fois les démarches effectuées via le mécanisme mentionné ci-dessus.
+
+## Contenu de la déclaration d’accessibilité
 
 **La déclaration d’accessibilité adopte obligatoirement ce format :**
 

--- a/src/obligations/declaration-accessibilite.md
+++ b/src/obligations/declaration-accessibilite.md
@@ -89,6 +89,7 @@ Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez 
 
 Envoyer un message [url du formulaire en ligne]
 Contacter [Nom de l’entité responsable du service en ligne] [url d’une page avec les coordonnées de l’entité]
+
 VOIES DE RECOURS
 
 Cette procédure est à utiliser dans le cas suivant.
@@ -107,7 +108,8 @@ La déclaration d’accessibilité est valide à partir de sa date de publicatio
 18 mois après la date de publication d’une nouvelle version du référentiel, pour les personnes qui appliquent la méthode technique.
 Il peut cependant être souhaitable de mettre à jour plus régulièrement la déclaration d’accessibilité, y compris pour une même version de la méthode technique, afin de souligner les efforts réalisés et de mettre à jour le pourcentage de critères respectés.
 
-Publication de la déclaration d’accessibilité
+## Publication de la déclaration d’accessibilité
+
 La déclaration d’accessibilité est publiée sur internet dans un format accessible.
 
 Pour les sites internet, la déclaration d’accessibilité est publiée sur le site internet concerné. Elle est mise à disposition au sein d’une page accessibilité, directement accessible depuis la page d’accueil et depuis n’importe quelle page du site.
@@ -118,7 +120,8 @@ Pour les autres services de communication au public en ligne, elle est disponibl
 
 La déclaration d’accessibilité fait l’objet d’un dépôt par le biais d’un téléservice selon les modalités arrêtées conjointement par le ministre chargé des personnes handicapées et le ministre chargé du numérique.
 
-Réponse aux usagers
+## Réponse aux usagers
+
 L’organisme concerné fournit en ligne aux utilisateurs la possibilité de faire des réclamations relatives à l’accessibilité de ses services de communication au public en ligne. Il accuse réception de ces réclamations conformément aux dispositions de l’article R112-3 du code des relations entre le public et l’Administration. L’accusé de réception comporte les informations mentionnées à l’article R112-5 du même code.
 
 L’organisme concerné répond à toute réclamation dans un délai d’une semaine à compte de sa date d’envoi. Si la réclamation de l’utilisateur soulève une ou plusieurs questions complexes justifiant un délai d’examen plus long, la réponse indique un délai raisonnable pour la réponse définitive. Le caractère complexe des questions soulevées doit être dûment motivé.


### PR DESCRIPTION
- Corrige les titres manquants
- Rend l'intro plus facilement « scannable »

Ce que je n'ai pas osé faire : 
- modifier les textes de l'intro, pour les rendre plus facile à lire et à comprendre 
- modifier les titres de la déclaration (actuellement, ils sont en majuscules et sans balisages. C'est une mauvaise pratique d'accessibilité 🤪)