### PR TITLE
Correction de Markdown dans le test 1.1.1

### DIFF
--- a/src/rgaa/criteres/1.1/tests/1.md
+++ b/src/rgaa/criteres/1.1/tests/1.md
@@ -1,5 +1,5 @@
 ---
-title: Chaque image (élément ``<img>`` ou balise ouvrante possédant l’attribut WAI-ARIA `role="img"`) [porteuse d’information](#porteuse-d-information) a-t-elle une [alternative textuelle](#alternative-textuelle) ?
+title: Chaque image (élément `<img>` ou balise ouvrante possédant l’attribut WAI-ARIA `role="img"`) [porteuse d’information](#porteuse-d-information) a-t-elle une [alternative textuelle](#alternative-textuelle) ?
 ---
 
 1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` ou d’un élément possédant l’attribut WAI-ARIA `role="img"` ;


### PR DESCRIPTION
Dans le title du frontmatter, il y avait des doubles backticks au lieu de simples.