### PR TITLE
 Correction de Markdown dans le test 1.4.3

### DIFF
--- a/RGAA/4.1/criteres.json
+++ b/RGAA/4.1/criteres.json
@@ -239,7 +239,7 @@
                 "S’il est présent, le [passage de texte](#passage-de-texte-lie-par-aria-labelledby-ou-aria-describedby) associé via l’attribut WAI-ARIA `aria-labelledby` est pertinent."
               ],
               "3": [
-                "Pour chaque [bouton](#bouton-formulaire) de type image (balise <input> avec l’attribut type=\"image\") utilisé comme [CAPTCHA](#captcha) ou comme [image-test](#image-test), ayant une [alternative textuelle](#alternative-textuelle-image), cette alternative est-elle pertinente ?",
+                "Pour chaque [bouton](#bouton-formulaire) de type image (balise `<input>` avec l’attribut type=\"image\") utilisé comme [CAPTCHA](#captcha) ou comme [image-test](#image-test), ayant une [alternative textuelle](#alternative-textuelle-image), cette alternative est-elle pertinente ?",
                 "S’il est présent, le contenu de l’attribut `alt` est pertinent ;",
                 "S’il est présent, le contenu de l’attribut `title` est pertinent ;",
                 "S’il est présent, le contenu de l’attribut WAI-ARIA `aria-label` est pertinent ;",


### PR DESCRIPTION
Dans le title du frontmatter, il manquait des backticks autour d'un "<input">. Ce qui rendait un input au lieu d'une balise `<code>`.