### PR TITLE
ajout des cas particuliers cf #152

### DIFF
--- a/src/rgaa/criteres/10.4/annexe.md
+++ b/src/rgaa/criteres/10.4/annexe.md
@@ -15,3 +15,11 @@ Techniques:
   - C17
   - C28
 ---
+
+#### Cas particuliers
+
+Font exception à ce critère, les contenus pour lesquels l’utilisateur n’a pas de possibilité de personnalisation :
+
+- Les sous-titres incrustés dans une vidéo ;
+- Les textes en image ;
+- Le texte au sein d’une balise `<canvas>`.


### PR DESCRIPTION
ajout des cas particuliers cf https://github.com/DISIC/accessibilite.numerique.gouv.fr/issues/152
sur la base des WCAG « À l’exception des [sous-titres](https://www.w3.org/Translations/WCAG21-fr/#dfn-captions) et du [texte sous forme d’image](https://www.w3.org/Translations/WCAG21-fr/#dfn-image-of-text), »
cf https://www.w3.org/Translations/WCAG21-fr/#resize-text