### PR TITLE
suppression de mentions à des technologies obsolètes

### DIFF
--- a/src/rgaa/criteres/4.7/tests/1.md
+++ b/src/rgaa/criteres/4.7/tests/1.md
@@ -2,8 +2,6 @@
 title: Pour chaque [média temporel](#media-temporel-type-son-video-et-synchronise) seulement son, seulement vidéo ou synchronisé, le contenu textuel adjacent permet-il d’identifier clairement le [média temporel](#media-temporel-type-son-video-et-synchronise) (hors cas particuliers) ?
 ---
 
-1. Retrouver dans le document les médias temporels pré-enregistrés seulement vidéo, audio ou synchronisés ;
-2. Pour chaque média temporel, vérifier que :
-   - Un passage de texte (un titre ou un paragraphe, par exemple) qui précède ou suit immédiatement le média temporel, permet de l’identifier ;
-   - Et le passage de texte est situé à l’extérieur du lecteur de contenu multimédia si ce dernier fait appel à la technologie Flash.
+1. Retrouver dans le document les médias temporels pré-enregistrés seulement vidéo, audio ou synchronisés.
+2. Pour chaque média temporel, vérifier qu'un passage de texte (un titre ou un paragraphe, par exemple) qui précède ou suit immédiatement le média temporel permet de l’identifier.
 3. Si c’est le cas pour chaque média temporel, **le test est validé**.

--- a/src/rgaa/glossaire/environnement-maitrise.md
+++ b/src/rgaa/glossaire/environnement-maitrise.md
@@ -5,7 +5,7 @@ title: Environnement maîtrisé
 Tout environnement dans lequel l’accès à l’information, les technologies, les conditions d’utilisation et le profil des utilisateurs peuvent être connus et maîtrisés. Les principaux éléments dont la maîtrise est essentielle sont :
 
 - Le type et la version des navigateurs ;
-- Les technologies supportées, leur version et leur activation (JavaScript, WAI-ARIA, Flash, Silverlight…) ;
+- Les technologies supportées, leur version et leur activation (JavaScript, WAI-ARIA…) ;
 - Les technologies d’assistance et tout dispositif utilisé de manière spécifique par les utilisateurs handicapés ;
 - Les systèmes d’exploitation et les APIs d’accessibilité supportées ;
 - La formation des utilisateurs de technologies d’assistance à l’utilisation de tout dispositif particulier (interface, application en ligne…).

--- a/src/rgaa/glossaire/media-non-temporel.md
+++ b/src/rgaa/glossaire/media-non-temporel.md
@@ -2,6 +2,4 @@
 title: Média non temporel
 ---
 
-Contenu qui ne se déroule pas dans le temps, consultable via un plugin (Flash, Java, Silverlight…) ou via les éléments `svg` et `canvas` ; par exemple, une carte interactive en Flash, une application Flash ou Java, un diaporama sont des médias non temporels. Un média non temporel peut contenir des médias temporels (un lecteur Flash qui propose une liste de vidéos à consulter, par exemple).
-
-Note : l’utilisation du paramètre `wmode` pour un objet Flash avec les valeurs `"transparent"` et `"opaque"` invalide de fait le {% crit 4.13 %}. En effet, l’utilisation de ces valeurs a pour conséquence que l’animation Flash vue du côté des utilisateurs de lecteur d’écran est invisible.
+Contenu qui ne se déroule pas dans le temps, consultable via les éléments `svg` et `canvas` ; par exemple, une animation interactive réalisée avec une balise `canvas`. Un média non temporel peut contenir des médias temporels (un diaporama réalisé avec `canvas` qui propose une liste de vidéos à consulter, par exemple).

--- a/src/rgaa/glossaire/media-temporel-type-son-video-et-synchronise.md
+++ b/src/rgaa/glossaire/media-temporel-type-son-video-et-synchronise.md
@@ -8,7 +8,6 @@ title: Média temporel (type son, vidéo et synchronisé)
 
 - Fichier à télécharger consultable avec un logiciel externe à la page web ;
 - Contenu embarqué dans la page web et consultable dans la page web via :
-  - Un plugin (par exemple une vidéo diffusée par un lecteur Flash) ;
   - L’élément `<video>` (par exemple une vidéo) ;
   - L’élément `<audio>` (par exemple un podcast) ;
   - L’élément `<svg>` (par exemple un dessin animé vectoriel) ;
@@ -17,8 +16,6 @@ title: Média temporel (type son, vidéo et synchronisé)
 
 Un média temporel peut être diffusé en temps réel ou être proposé en lecture de manière asynchrone (média pré-enregistré).
 
-Note 1 : l’utilisation du paramètre `wmode` pour un objet Flash avec les valeurs `"transparent"` et `"opaque"` invalide de fait le {% crit 4.13 %}. En effet, l’utilisation de ces valeurs a pour conséquence que l’animation Flash vue du côté des utilisateurs de lecteur d’écran est invisible.
+Note 1 : les gif animés, les animations d’images réalisées par JavaScript ou CSS ne sont pas considérés comme étant des médias temporels.
 
-Note 2 : les gif animés, les animations d’images réalisées par JavaScript ou CSS ne sont pas considérés comme étant des médias temporels.
-
-Note 3 : l’élément `<bgsound>` est spécifique à Internet Explorer et ne devrait pas être utilisé.
+Note 2 : l’élément `<bgsound>` est spécifique à Internet Explorer et ne devrait pas être utilisé.


### PR DESCRIPTION
Proposition de suppression du RGAA des mentions aux technologies Flash, Silverlight et Java.

Fin du support de ces technologies:
- Silverlight: 2021 ;
- Flash : 2021 ;
- Java (Applet) : 2020.

Les éléments du référentiel impactés sont les suivants :

- La méthodologie du critère [4.7](https://accessibilite.public.lu/fr/raweb1/criteres.html#crit-4-7) : suppression du test "le passage de texte est situé à l’extérieur du lecteur de contenu multimédia si ce dernier fait appel à la technologie Flash".
- L’entrée de glossaire « Environnement maîtrisé » : les références à Flash et Silverlight sont supprimées dans le second item de liste "Les technologies supportées, leur version et leur activation (JavaScript, WAI-ARIA, Flash, Silverlight…)".
- L’entrée de glossaire « Média non temporel » : toutes les références à Flash, Java et Silverlight ainsi qu’à leurs propriétés y sont supprimées.
- L’entrée de glossaire « Média temporel (type son, vidéo et synchronisé)  » : toutes les références à Flash ainsi qu’à ses propriétés y sont supprimées. La note 1 est supprimée : la note 2 devient la note 1, et la note 3 devient la note 2.