### PR TITLE
précision du test 4.4.1

### DIFF
--- a/src/rgaa/criteres/4.4/tests/1.md
+++ b/src/rgaa/criteres/4.4/tests/1.md
@@ -1,9 +1,14 @@
 ---
-title: Pour chaque [média temporel](#media-temporel-type-son-video-et-synchronise) synchronisé pré-enregistré ayant des [sous-titres synchronisés](#sous-titres-synchronises-objet-multimedia), ces sous-titres sont-ils pertinents ?
+title: Pour chaque [média temporel](#media-temporel-type-son-video-et-synchronise) synchronisé pré-enregistré ayant des [sous-titres synchronisés](#sous-titres-synchronises-objet-multimedia), une piste de sous-titres au moins respecte-t-elle ces conditions ?
+steps:
+- Les sous-titres sont dans la langue de la vidéo ;
+- Les sous-titres sont pertinents ;
+- Les sous-titres sont correctement synchronisés. 
 ---
 
-1. Retrouver dans le document les médias temporels synchronisés possédant des sous-titres synchronisés ;
+1. Retrouver dans le document les médias temporels synchronisés possédant des sous-titres synchronisés.
 2. Pour chaque média temporel synchronisé, vérifier que les sous-titres sont :
-   - Pertinents (toutes les informations sonores importantes sont présentes, les dialogues notamment) ;
-   - Et correctement synchronisés.
+	- dans la langue de la vidéo (si le contenu oralisé est en anglais, les sous-titres doivent être en anglais) ; 
+	- pertinents (toutes les informations sonores importantes sont présentes, les dialogues notamment) ;
+	- correctement synchronisés. Si vous n’observez pas de décalage entre le discours oralisé et l’apparition des sous-titres, les sous-titres sont correctement synchronisés. La norme de référence spécifie que les sous-titres doivent apparaître dans les 100&nbsp;ms suivant l’[horodatage du sous-titre](#horodatage-time-stamp).
 3. Si c’est le cas pour chaque média temporel synchronisé, **le test est validé**.

--- a/src/rgaa/glossaire/horodatage-time-stamp.md
+++ b/src/rgaa/glossaire/horodatage-time-stamp.md
@@ -1,0 +1,10 @@
+---
+title: Horodatage (<em lang="en">time stamp</em>)
+---
+
+L’horodatage d’une vidéo (<em lang="en">time stamp</em>) est la valeur temporelle déclarée dans le fichier de sous-titres.
+
+<pre><code>1
+00:00:03,000 --&gt; 00:00:06,999
+Le sous-titre doit apparaître lorsque la vidéo atteint 3 secondes.
+</code></pre>


### PR DESCRIPTION
Proposition de réécriture du test 4.4.1 pour préciser les éléments de tests, qui nous semblent trop implicites, notamment le fait que les sous-titres pour sourds et malentendants sont nécessairement dans la langue de la vidéo (captions vs subtitles)

Cette modification provient des travaux réalisés dans le cadre du RAWeb 1.