### PR TITLE
Suppression des références à l’attribut longdesc

### DIFF
--- a/src/rgaa/criteres/1.6/annexe.md
+++ b/src/rgaa/criteres/1.6/annexe.md
@@ -18,5 +18,3 @@ Dans le cas du SVG, le manque de support de l’élément `<title>` et `<desc>` 
 L’utilisation de l’attribut WAI-ARIA aria-describedby n’est pas recommandée pour lier une image (`<img>`, `<object>`, `<embed>`, `<canvas>`) à sa [description détaillée](#description-detaillee-image), par manque de support des technologies d’assistance. Néanmoins, lorsqu’il est utilisé, l’attribut devra nécessairement faire référence à l’`id` de la zone contenant la [description détaillée](#description-detaillee-image).
 
 La [description détaillée](#description-detaillee-image) adjacente peut être implémentée via une balise `<figcaption>`, dans ce cas le critère 1.9 doit être vérifié (utilisation de `<figure>` et des attributs WAI-ARIA `role="figure"` et `aria-label`, notamment).
-
-L'attribut `longdesc` qui constitue une des conditions du test 1.6.1 (et dont la pertinence est vérifiée avec le test 1.7.1) est désormais considéré comme obsolète par la spécification HTML en cours. La vérification de cet attribut ne sera donc requise que pour les versions de la spécification HTML antérieure à HTML 5.

--- a/src/rgaa/criteres/1.6/tests/1.md
+++ b/src/rgaa/criteres/1.6/tests/1.md
@@ -1,14 +1,12 @@
 ---
 title: Chaque image (balise `<img>`) [porteuse d’information](#image-porteuse-d-information), qui nécessite une [description détaillée](#description-detaillee-image), vérifie-t-elle une de ces conditions ?
 steps:
-  - Il existe un attribut `longdesc` qui donne l’adresse (URL) d’une page ou d’un emplacement dans la page contenant la [description détaillée](#description-detaillee-image) ;
-  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image ;
+  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image.
   - Il existe un [lien ou un bouton adjacent](#lien-ou-bouton-adjacent) permettant d’accéder à la [description détaillée](#description-detaillee-image).
 ---
 
-1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` (ou d’un élément possédant l’attribut WAI-ARIA `role="img"`) porteuses d’information qui nécessitent une description détaillée ;
+1. Retrouver dans le document les images structurées au moyen d’un élément `<img>` (ou d’un élément possédant l’attribut WAI-ARIA `role="img"`) porteuses d’information qui nécessitent une description détaillée.
 2. Pour chaque image, vérifier qu’il existe :
-   - Soit un attribut longdesc qui donne l’adresse (url) d’une page ou d’un emplacement dans la page contenant la description détaillée ;
    - Soit une alternative textuelle contenant la référence à une description détaillée adjacente à l’image ;
    - Soit un lien ou un bouton adjacent permettant d’accéder à la description détaillée.
 3. Si c’est le cas pour chaque image, **le test est validé**.

--- a/src/rgaa/criteres/1.6/tests/2.md
+++ b/src/rgaa/criteres/1.6/tests/2.md
@@ -1,8 +1,7 @@
 ---
 title: Chaque [image objet](#image-objet) (balise `<object>` avec l’attribut `type="image/…"`) [porteuse d’information](#image-porteuse-d-information), qui nécessite une [description détaillée](#description-detaillee-image), vérifie-t-elle une de ces conditions ?
 steps:
-  - Il existe un attribut `longdesc` qui donne l’adresse (URL) d’une page ou d’un emplacement dans la page contenant la [description détaillée](#description-detaillee-image) ;
-  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image ;
+  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image.
   - Il existe un [lien ou un bouton adjacent](#lien-ou-bouton-adjacent) permettant d’accéder à la [description détaillée](#description-detaillee-image).
 ---
 

--- a/src/rgaa/criteres/1.6/tests/3.md
+++ b/src/rgaa/criteres/1.6/tests/3.md
@@ -1,8 +1,7 @@
 ---
 title: Chaque image embarquée (balise `<embed>`) [porteuse d’information](#image-porteuse-d-information), qui nécessite une [description détaillée](#description-detaillee-image), vérifie-t-elle une de ces conditions ?
 steps:
-  - Il existe un attribut `longdesc` qui donne l’adresse (URL) d’une page ou d’un emplacement dans la page contenant la [description détaillée](#description-detaillee-image) ;
-  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image ;
+  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image.
   - Il existe un [lien ou un bouton adjacent](#lien-ou-bouton-adjacent) permettant d’accéder à la [description détaillée](#description-detaillee-image).
 ---
 

--- a/src/rgaa/criteres/1.6/tests/4.md
+++ b/src/rgaa/criteres/1.6/tests/4.md
@@ -1,9 +1,9 @@
 ---
 title: Chaque [bouton](#bouton-formulaire) de type image (balise `<input>` avec l’attribut `type="image"`) [porteur d’information](#image-porteuse-d-information), qui nécessite une [description détaillée](#description-detaillee-image), vérifie-t-il une de ces conditions ?
 steps:
-  - Il existe un attribut `longdesc` qui donne l’adresse (URL) d’une page ou d’un emplacement dans la page contenant la [description détaillée](#description-detaillee-image) ;
-  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image ;
+  - Il existe une [alternative textuelle](#alternative-textuelle-image) contenant la référence à une [description détaillée](#description-detaillee-image) adjacente à l’image.
   - Il existe un [lien ou un bouton adjacent](#lien-ou-bouton-adjacent) permettant d’accéder à la [description détaillée](#description-detaillee-image).
+  - Il existe un attribut WAI-ARIA `aria-describedby` associant un [passage de texte](#passage-de-texte-lie-par-aria-labelledby-ou-aria-describedby) faisant office de [description détaillée](#description-detaillee-image).
 ---
 
 1. Retrouver dans le document les éléments `<input>` pourvus de l’attribut `type="image"`, porteurs d’information qui nécessitent une description détaillée ;

--- a/src/rgaa/criteres/1.7/tests/1.md
+++ b/src/rgaa/criteres/1.7/tests/1.md
@@ -1,9 +1,8 @@
 ---
 title: Chaque image (balise `<img>`) [porteuse d’information](#image-porteuse-d-information), ayant une [description détaillée](#description-detaillee-image), vérifie-t-elle ces conditions ?
 steps:
-  - La [description détaillée](#description-detaillee-image) via l’adresse référencée dans l’attribut `longdesc` est pertinente ;
-  - La [description détaillée](#description-detaillee-image) dans la page et signalée par l’[alternative textuelle](#alternative-textuelle-image) est pertinente ;
-  - La [description détaillée](#description-detaillee-image) via un [lien ou un bouton adjacent](#lien-ou-bouton-adjacent) est pertinente ;
+  - La [description détaillée](#description-detaillee-image) dans la page et signalée par l’[alternative textuelle](#alternative-textuelle-image) est pertinente.
+  - La [description détaillée](#description-detaillee-image) via un [lien ou un bouton adjacent](#lien-ou-bouton-adjacent) est pertinente.
   - Le passage de texte associé via l’attribut WAI-ARIA `aria-describedby` est pertinent.
 ---
 

--- a/src/rgaa/glossaire/description-detaillee-image.md
+++ b/src/rgaa/glossaire/description-detaillee-image.md
@@ -4,7 +4,6 @@ title: Description détaillée (image)
 
 Contenu associé à une image en complément de son alternative textuelle afin de décrire en totalité l’information véhiculée par l’image. La description détaillée peut être associée à l’image via :
 
-- Un attribut `longdesc` qui contient l’adresse d’une page ou d’un emplacement dans la page contenant la description détaillée ;
 - Une référence à une description détaillée adjacente à l’image dans l’alternative textuelle ;
 - Un [lien ou un bouton adjacent](#lien-ou-bouton-adjacent) qui permet d’accéder à la description détaillée dans la page ou dans une autre page ;
 - Un ou plusieurs passages de texte identifiés par un id et liés par un attribut WAI-ARIA `aria-describedby` sur le modèle `aria-describedby="ID1 ID2 ID3…"`.


### PR DESCRIPTION
Proposition de suppression de l’attribut longdesc en tant que méthode conforme pour les critères 1.6 et 1.7. En effet, l’attribut longdesc a été déclaré obsolète dans la spécification HTML5. De plus, le support de l’attribut est insuffisant au regard de l’environnement de test, on constate notamment une absence de support en environnement mobile (Safari/iOS et Chrome/Talkback).

Dans le test 1.6.1, la condition suivante est supprimée : "Il existe un attribut longdesc qui donne l’adresse (URL) d’une page ou d’un emplacement dans la page contenant la description détaillée". La méthodologie de test est adaptée en conséquence.

Dans la note technique du critère 1.6, le passage concernant l’attribut longdesc est supprimé :

L’attribut longdesc qui constitue une des conditions du test 1.6.1 (et dont la pertinence est vérifiée avec le test 1.7.1) est désormais considéré comme obsolète par la spécification HTML en cours. La vérification de cet attribut ne sera donc requise que pour les versions de la spécification HTML antérieure à HTML 5. 

Dans le test 1.7.1, la condition suivante est supprimée : "La description détaillée via l’adresse référencée dans l’attribut longdesc est pertinente". La méthodologie de test est adaptée en conséquence.

Dans le glossaire, l’entrée « Description détaillée (image) » est modifiée. L’item "Un attribut longdesc qui contient l’adresse d’une page ou d’un emplacement dans la page contenant la description détaillée" est supprimé.

Cette modification provient des travaux réalisés dans le cadre du RAWeb 1.