### PR TITLE
Suppression du critère WCAG de l’analyse syntaxique

### DIFF
--- a/src/ressources/methodologie-de-test.md
+++ b/src/ressources/methodologie-de-test.md
@@ -35,8 +35,7 @@ Les barres d’outils sont des extensions du navigateur qui vont faciliter le re
 À noter que la Web Accessibility Toolbar pour Internet Explorer n'est plus maintenu par son éditeur (Paciello Group).
 
 Au-delà de la simple barre d’outil, d’autres outils fournissent une analyse complète du document en signalant visuellement sur la page les erreurs d’accessibilité ou à l’inverse les éléments qui lui sont bénéfiques ; des filtres permettent alors souvent de n’afficher que certains de ces aspects. C’est ce que propose Wave, une solution disponible à la fois en ligne (http://wave.webaim.org) et comme extension de navigateur (https://wave.webaim.org/extension/).
-
-La validation du code source d’un document HTML utilise le validateur en ligne du W3C (https://validator.w3.org/nu/). À noter que pour valider le code source généré par le navigateur, il faut utiliser l’option "Text input" de la liste de sélection intitulé "Check by" et copier dans la zone de saisie multiligne qui est alors proposée, la source HTML disponible à partir de l’inspecteur de code du navigateur.
+Bien qu’il ne soit plus requis de contrôler la validité du code source, il peut être utile, à des fins de recherches d’anomalies, d'utiliser le validateur HTML. La validation du code source d’un document HTML utilise le validateur en ligne du W3C (https://validator.w3.org/nu/). À noter que pour valider le code source généré par le navigateur, il faut utiliser l’option "Text input" de la liste de sélection intitulé "Check by" et copier dans la zone de saisie multiligne qui est alors proposée, la source HTML disponible à partir de l’inspecteur de code du navigateur.
 Des extensions de navigateur sont aussi disponibles, mais il faut être vigilant, car les algorithmes de validation de ces extensions ne sont pas forcément à jour par rapport au validateur du W3C et les résultats obtenus peuvent donc être différents.
 
 La vérification des contrastes de couleurs bénéficie de différents outils :

--- a/src/rgaa/criteres/8.1/annexe.md
+++ b/src/rgaa/criteres/8.1/annexe.md
@@ -7,3 +7,8 @@ Techniques:
   - G134
   - G192
 ---
+
+#### Note 
+
+Les technologies d’assistance ne dépendent plus de l’analyse directe du HTML. L’absence de déclaration d’un type de document ne pose donc plus de problème d’accessibilité pour les personnes en situation de handicap.
+Le critère doit dorénavant toujours être considéré comme conforme.

--- a/src/rgaa/criteres/8.1/tests/1.md
+++ b/src/rgaa/criteres/8.1/tests/1.md
@@ -1,9 +1,3 @@
 ---
-title: Pour chaque page web, le [type de document](#type-de-document) (balise `doctype`) est-il présent ?
+title: Chaque page web est-elle définie par un [type de document](#type-de-document) ?
 ---
-
-1. Retrouver dans le document la balise DOCTYPE (par exemple `<!DOCTYPE html>`) ;
-2. Vérifier que :
-   - La balise DOCTYPE est placée avant la balise `<html>` ;
-   - Le type de document est valide.
-3. Si c’est le cas, **le test est validé**.

--- a/src/rgaa/criteres/8.1/tests/2.md
+++ b/src/rgaa/criteres/8.1/tests/2.md
@@ -1,5 +1,0 @@
----
-title: Pour chaque page web, le [type de document](#type-de-document) (balise `doctype`) est-il valide ?
----
-
-Tests identiques à 8.1.1

--- a/src/rgaa/criteres/8.1/tests/3.md
+++ b/src/rgaa/criteres/8.1/tests/3.md
@@ -1,5 +1,0 @@
----
-title: Pour chaque page web possédant une déclaration de [type de document](#type-de-document), celle-ci est-elle située avant la balise `<html>` dans le code source ?
----
-
-Tests identiques à 8.1.1

--- a/src/rgaa/criteres/8.2/annexe.md
+++ b/src/rgaa/criteres/8.2/annexe.md
@@ -13,3 +13,8 @@ Techniques:
   - F70
   - F77
 ---
+
+#### Note 
+
+Les technologies d’assistance ne dépendent plus de l’analyse directe du HTML. Les problèmes d’accessibilité spécifiquement liés à la validité du code n’existent plus. Les erreurs remontées par le validateur qui ont un impact pour les personnes en situation de handicap sont traitées par d’autres critères.
+Le critère doit dorénavant toujours être considéré comme conforme.

--- a/src/rgaa/criteres/8.2/tests/1.md
+++ b/src/rgaa/criteres/8.2/tests/1.md
@@ -1,18 +1,4 @@
 ---
-title: Pour chaque déclaration de [type de document](#type-de-document), le code source généré de la page vérifie-t-il ces conditions ?
-steps:
-  - Les balises, attributs et valeurs d’attributs respectent les [règles d’écriture](#regles-d-ecriture) ;
-  - L’imbrication des balises est conforme ;
-  - L’ouverture et la fermeture des balises sont conformes ;
-  - Les valeurs d’attribut id sont uniques dans la page ;
-  - Les attributs ne sont pas doublés sur un même élément.
+title: Pour chaque page web, le code source généré est-il valide selon le [type de document](#type-de-document) spécifié ?
 ---
 
-1. Dans le menu « Check », activer l’option « W3C Nu markup checker (all frames) ».
-2. Dans la page de résultats, vérifier que :
-   - Les balises, attributs et valeurs d’attributs respectent les règles d’écriture ;
-   - L’imbrication des balises est conforme ;
-   - L’ouverture et la fermeture des balises sont conformes ;
-   - Les valeurs d’attribut id sont uniques dans la page ;
-   - Les attributs ne sont pas doublés sur un même élément.
-3. Si c’est le cas, **le test est validé**.


### PR DESCRIPTION
Le groupe de travail WCAG a publié une [mise à jour des WCAG 2.1 le 21 septembre 2023](https://www.w3.org/TR/WCAG21/#parsing) indiquant que le [critère de succès 4.1.1 Parsing](https://www.w3.org/TR/WCAG21/#parsing) devait dorénavant être toujours considéré comme conforme.

Le RGAA étant une transposition des WCAG 2.1, nous proposons d'appliquer ce choix aux critères correspondants dans le RGAA. Ainsi, les critères 8.1 et 8.2 du RAWeb ne sont plus à tester et doivent toujours être considérés comme conformes.

Les critères sont conservés dans le référentiel (pour préserver la numérotation des critères de la thématique « Éléments obligatoires ») et sont accompagnés d’une note.

Cette modification provient des travaux réalisés dans le cadre du RAWeb 1.