### PR TITLE
Principe de non-interférence

### DIFF
--- a/src/obligations/evaluation-conformite.md
+++ b/src/obligations/evaluation-conformite.md
@@ -91,3 +91,25 @@ Le pourcentage de critères RGAA respectés s’obtient en divisant le nombre de
 - Critère applicable : pour qu’un critère soit applicable, il suffit qu’il le soit sur une seule page de l’échantillon. Ce qui a pour corollaire qu’un critère est non applicable s’il est non applicable sur toutes les pages de l’échantillon sans exception.
 
 Le taux de moyen de conformité du service en ligne s’obtient en faisant la moyenne des taux de conformité de chaque page.
+
+## Principe de non-interférence
+
+Dans un échantillon d’audit, il peut y avoir des contenus qui ne sont pas soumis à l’obligation de mise en accessibilité :
+
+- les [contenus exemptés](#contenus-exemptés) ;
+- les [contenus dérogés pour charge disproportionnée](#dérogation-pour-charge-disproportionnée) ;
+- les contenus non accessibles qui disposent d’une alternative accessible.
+
+Il est indispensable de s’assurer que ces contenus n’empêchent pas les utilisateurs d’accéder au reste de la page.
+
+Ainsi, bien que la conformité de ces contenus ne soit pas requise, il reste obligatoire qu’ils se conforment aux critères et tests suivants :
+
+- Critère 4.10 : Chaque son déclenché automatiquement est-il contrôlable par l’utilisateur ?
+- Critère 12.9 : Dans chaque page web, la navigation ne doit pas contenir de piège au clavier. Cette règle est-elle respectée ?
+- Test 13.1.1 : Pour chaque page web, chaque procédé de rafraîchissement (balise `<object>`, balise `<embed>`, balise `<svg>`, balise `<canvas>`, balise `<meta>`) vérifie-t-il une de ces conditions (hors cas particuliers) ?
+- Critère 13.7 : Dans chaque page web, les changements brusques de luminosité ou les effets de flash sont-ils correctement utilisés ?
+- Critère 13.8 : Dans chaque page web, chaque contenu en mouvement ou clignotant est-il contrôlable par l’utilisateur ?
+
+Le non-respect de l’un de ces critères ou tests pour l’un des types de contenus énumérés rend le ou les critères correspondants non conformes.
+
+Le principe de non-interférence est identifié dans la norme EN 301 549 au critère 9.6 WCAG <span lang="en">conformance requirements</span>.

--- a/src/rgaa/criteres/12.9/annexe.md
+++ b/src/rgaa/criteres/12.9/annexe.md
@@ -11,3 +11,7 @@ Techniques:
   - H91
   - F10
 ---
+
+#### Note
+
+Ce critère est soumis au [principe de non-interférence](../../obligations/evaluation-conformite/#principe-de-non-interférence).

--- a/src/rgaa/criteres/13.1/annexe.md
+++ b/src/rgaa/criteres/13.1/annexe.md
@@ -30,3 +30,7 @@ Techniques:
 Il existe une gestion de cas particuliers lorsque la limite de temps est essentielle, notamment lorsqu’elle ne pourrait pas être supprimée sans changer fondamentalement le contenu ou les fonctionnalités liées au contenu.
 
 Dans ces situations, le critère est non applicable. Par exemple, le rafraîchissement d’un flux RSS dans une page n’est pas une limite de temps essentielle ; le critère est applicable. En revanche, une redirection automatique qui amène vers la nouvelle version d’une page à partir d’une URL obsolète est essentielle ; le critère est non applicable.
+
+#### Note
+
+Le test 13.1.1 de ce critère est soumis au [principe de non-interférence](../../obligations/evaluation-conformite/#principe-de-non-interférence).

--- a/src/rgaa/criteres/13.7/annexe.md
+++ b/src/rgaa/criteres/13.7/annexe.md
@@ -8,3 +8,7 @@ Techniques:
   - G19
   - G176
 ---
+
+#### Note
+
+Ce critère est soumis au [principe de non-interférence](../../obligations/evaluation-conformite/#principe-de-non-interférence).

--- a/src/rgaa/criteres/13.8/annexe.md
+++ b/src/rgaa/criteres/13.8/annexe.md
@@ -24,3 +24,7 @@ Techniques:
   - SM11
   - SM12
 ---
+
+#### Note
+
+Ce critère est soumis au [principe de non-interférence](../../obligations/evaluation-conformite/#principe-de-non-interférence).

--- a/src/rgaa/criteres/4.10/annexe.md
+++ b/src/rgaa/criteres/4.10/annexe.md
@@ -10,3 +10,7 @@ Techniques:
   - F23
   - F93
 ---
+
+#### Note
+
+Ce critère est soumis au [principe de non-interférence](../../obligations/evaluation-conformite/#principe-de-non-interférence).


### PR DESCRIPTION
Proposition d'ajout d'une nouvelle section « Principe de non-interférence » dans la page "évaluation de la conformité à la norme de référence" et d'une mention de ce principe dans chaque critère concerné dnas le référentiel technique.

Ce principe est décrit dans la norme européenne dans le critère [9.6 WCAG conformance requirements](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=51) et dans la [5e exigence de conformité de WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/conformance#conf-req5).

Il permet de clarifier les cas où un contenu ou une fonctionnalité ne peuvent être considérés comme dérogés, exemptés ou disposant d'une alternative accessible, car ils interfèrent avec l'accessibilité du reste du site.