### PR TITLE
Exemple, dans le glossaire, moins problématique, plus neutre 

### DIFF
--- a/src/rgaa/glossaire/lien-dont-la-nature-n-est-pas-evidente.md
+++ b/src/rgaa/glossaire/lien-dont-la-nature-n-est-pas-evidente.md
@@ -2,6 +2,6 @@
 title: Lien dont la nature n’est pas évidente
 ---
 
-Lien qui peut être confondu avec un texte normal lorsqu’il est signalé uniquement par la couleur par certains types d’utilisateurs ne percevant pas ou mal les couleurs. Par exemple, dans ce texte “Nouvelle grève à la SNCF”, si le mot “grève” est un lien signalé uniquement par la couleur, sa nature peut être ignorée par les utilisateurs ne percevant pas la couleur et accédant au contenu CSS activé.
+Lien qui peut être confondu avec un texte normal lorsqu’il est signalé uniquement par la couleur par certains types d’utilisateurs ne percevant pas ou mal les couleurs. Par exemple, dans ce texte “Nouveaux horaires d'été”, si le mot “horaires” est un lien signalé uniquement par la couleur, sa nature peut être ignorée par les utilisateurs ne percevant pas la couleur et accédant au contenu CSS activé.
 
 Note : “signalés uniquement par la couleur” signifie que le lien n’est accompagné d’aucun marqueur visuel (icône, soulignement, bordure…). En conséquence, un lien de la même couleur que le texte environnant est concerné par ce critère.


### PR DESCRIPTION
Évitons de faire du service public bashing jusque dans le RGAA en associant SNCF et grève, c'est totalement déplacé et même délétère.