### PR TITLE
cohérence avec WCAG dans le critère 3.2

### DIFF
--- a/src/rgaa/criteres/3.2/tests/2.md
+++ b/src/rgaa/criteres/3.2/tests/2.md
@@ -1,11 +1,11 @@
 ---
-title: Dans chaque page web, le texte et le texte en image en gras d’une taille restituée inférieure à 18,5px vérifient-ils une de ces conditions (hors cas particuliers) ?
+title: Dans chaque page web, le texte et le texte en image en gras d’une taille restituée inférieure à 18,7px vérifient-ils une de ces conditions (hors cas particuliers) ?
 steps:
   - Le rapport de [contraste](#contraste) entre le texte et son arrière-plan est de 4.5:1, au moins ;
   - Un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de [contraste](#contraste) de 4.5:1, au moins.
 ---
 
-1. Retrouver dans le document les textes et les textes en image en gras d’une taille restituée inférieure à 18,5px qui pourraient poser des problèmes de contraste ;
+1. Retrouver dans le document les textes et les textes en image en gras d’une taille restituée inférieure à 18,7px qui pourraient poser des problèmes de contraste ;
 2. Pour chacun de ces textes, vérifier que :
    - Soit le rapport de contraste entre le texte et son arrière-plan est de 4.5:1, au moins ;
    - Soit un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de contraste de 4.5:1, au moins.

--- a/src/rgaa/criteres/3.2/tests/4.md
+++ b/src/rgaa/criteres/3.2/tests/4.md
@@ -1,11 +1,11 @@
 ---
-title: Dans chaque page web, le texte et le texte en image en gras d’une taille restituée supérieure ou égale à 18,5px vérifient-ils une de ces conditions (hors cas particuliers) ?
+title: Dans chaque page web, le texte et le texte en image en gras d’une taille restituée supérieure ou égale à 18,7px vérifient-ils une de ces conditions (hors cas particuliers) ?
 steps:
   - Le rapport de [contraste](#contraste) entre le texte et son arrière-plan est de 3:1, au moins ;
   - Un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de [contraste](#contraste) de 3:1, au moins.
 ---
 
-1. Retrouver dans le document les textes et les textes en image en gras d’une taille restituée supérieure ou égale à 18,5px qui pourraient poser des problèmes de contraste ;
+1. Retrouver dans le document les textes et les textes en image en gras d’une taille restituée supérieure ou égale à 18,7px qui pourraient poser des problèmes de contraste ;
 2. Pour chacun de ces textes, vérifier que :
    - Soit le rapport de contraste entre le texte et son arrière-plan est de 3:1, au moins ;
    - Soit un mécanisme permet à l’utilisateur d’afficher le texte avec un rapport de contraste de 3:1, au moins.


### PR DESCRIPTION
Dans la suite de tests du critère 3.2, la valeur de 18,5px est retenue pour la taille de police agrandie en gras.
Or si l'on se réfère aux WCAG, [la valeur exacte est 14pt](https://www.w3.org/TR/WCAG22/#dfn-large-scale). 14pt correspond à 18.7px.
C'est la valeur qui est retenue dans le [critère 9.1.4.3 du BITV](https://bitvtest.de/pruefschritt/bitv-20-web/bitv-20-web-9-1-4-3-kontraste-von-texten-ausreichend).

Proposition de correction initiale par @inseo sur le [RAWeb](https://github.com/accessibility-luxembourg/ReferentielAccessibiliteWeb/issues/2)

cf issue #198